### PR TITLE
Fix filename case in #include directives

### DIFF
--- a/src/EventManager.h
+++ b/src/EventManager.h
@@ -1,7 +1,7 @@
 #ifndef EVENT_MANAGER
 #define EVENT_MANAGER
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif

--- a/src/Task.h
+++ b/src/Task.h
@@ -2,7 +2,7 @@
 #define TIME_SEQUENCE
 
 #if defined(ARDUINO) && ARDUINO >= 100
-	#include "arduino.h"
+	#include "Arduino.h"
 #else
 	#include "WProgram.h"
 #endif


### PR DESCRIPTION
Incorrect capitalization of the filenames caused compilation to fail on filename case-sensitive operating systems like Linux.